### PR TITLE
Change alias environment name to env_alias (bash)

### DIFF
--- a/env-exporter.sh
+++ b/env-exporter.sh
@@ -109,8 +109,8 @@ main() {
   debug "debug : $debug"
 
   local app
-  if [ -n $app_alias ]; then
-    app=$app_alias
+  if [ -n $env_alias ]; then
+    app=$env_alias
   else
     app=$(basename $1) || exit 0
   fi


### PR DESCRIPTION
To follow the latest spec, [doc](https://forum.snapcraft.io/t/the-env-injector-extension/41477), and be consistent with the Rust implementation:

https://github.com/canonical/snappy-env/blob/40554247b190928b1b0c7c8d7ad9a084064eaf38/src/main.rs#L131