### PR TITLE
add: smoke tests and usage instructions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,41 @@
+name: Build and Test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  # Allow manual trigger
+  workflow_dispatch:
+
+env:
+  SNAP: envtester_${{ github.run_id}}.snap
+
+jobs:
+  build-and-test:
+    outputs:
+      snap: ${{ steps.snapcraft.outputs.snap }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Initialize tests
+        run: sudo ./tests/initialize 
+
+      - name: Build snap
+        uses: snapcore/action-build@v1
+        id: snapcraft
+
+      - name: Install snap
+        run: sudo snap install *.snap --dangerous
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.SNAP }}
+          path: ${{ steps.snapcraft.outputs.snap }}
+          if-no-files-found: error
+
+      - name: Run tests
+        run: sudo ./tests/test-snappyenv

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,12 @@
+# snappy-env smoke tests
+
+These are smoke tests that check if the main functionalities of `bash` and `rust` versions of `snappy-env` program are working.
+
+## Running tests
+
+To run tests, execute the `test-snappyenv` script with root privileges:
+
+```
+sudo ./test-snappyenv
+```
+

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,6 +1,6 @@
 # snappy-env smoke tests
 
-These are smoke tests that check if the main functionalities of `bash` and `rust` versions of `snappy-env` program are working.
+These are smoke tests that check if the main functionalities of the `rust` implementation of `snappy-env` program are working.
 
 ## Running tests
 

--- a/tests/initialize
+++ b/tests/initialize
@@ -1,0 +1,100 @@
+#!/bin/bash
+
+check_syntax() {
+  local snap_app="$1"
+  local env_value="$2"
+  if eval "$snap_app" | grep -q "^${env_value}="; then
+    echo -e "\n[ERROR] Value '$env_name' SHOULD NOT BE set.\n"
+    return 1
+  fi
+  return 0
+}
+
+check_env_exist() {
+  local snap_app="$1"
+  local env_name="$2"
+
+  if ! eval "$snap_app" | grep -q "^${env_name}="; then
+    echo -e "\n[ERROR] Environment variable '$env_name' is not set, for the app: $snap_app.\n"
+    return 1
+  fi
+}
+
+check_env_not_exist() {
+
+  local snap_app="$1"
+  local env_name="$2"
+
+  if eval "$snap_app" | grep -q "^${env_name}="; then
+    echo -e "\n[ERROR] Environment variable '$env_name' SHOULD NOT be set, for the app: $snap_app.\n"
+    return 1
+  fi
+}
+
+check_env_value() {
+  local snap_app="$1"
+  local env_name="$2"
+  local exp_value="$3"
+  local actual_value
+
+  if [ -z "$env_name" ]; then
+    echo -e "\n\nHERE HERE\n\n "
+    empty=$("$snap_app" | grep "=${exp_value}")
+    [ -z "$empty" ] || return 1
+  fi
+  actual_value=$("$snap_app" | grep "^${env_name}=" | cut -d'=' -f2-)
+  if [ "$actual_value" != "$exp_value" ]; then
+    echo -e "\n[ERROR] Environment variable '$env_name' does not match the expected value, for the app: $snap_app"
+    echo -e "[ERROR] Expected: '$env_name=$exp_value', but got: '$env_name=$actual_value'\n"
+    return 1
+  fi
+}
+
+check_root() {
+  if [ "$USER" != "root" ]; then
+    echo -e "Please run as root.\n"
+    exit 1
+  fi
+}
+
+clean() {
+  echo "Cleaning..."
+  snap remove --purge "${SNAP}"
+  git restore snap/snapcraft.yaml
+  sudo chown $SUDO_USER:$SUDO_USER snap/snapcraft.yaml
+
+  rm -rf squashfs-root
+}
+
+fail() {
+  clean
+  exit 1
+}
+
+inject_test_app() {
+  sudo snap install yq
+  sudo -u "$SUDO_USER" yq '.apps.app-rust-2 = {
+  "environment": {
+    "env_alias": "app-rust-2"
+  },
+  "command-chain": [
+    "bin/env-exporter"
+  ],
+  "command": "bin/env.sh"
+  }' -i "snap/snapcraft.yaml"
+}
+
+init_tests() {
+  set +u
+  if [ -z "${GITHUB_ACTIONS}" ]; then
+    set -u
+    inject_test_app
+    snapcraft -o "${SNAP}".snap
+    snap install "${SNAP}".snap --dangerous
+  fi
+}
+
+SNAP=envtester
+SNAP_COMMON=/var/snap/"${SNAP}"/common/
+
+inject_test_app

--- a/tests/test-snappyenv
+++ b/tests/test-snappyenv
@@ -38,6 +38,7 @@ check_root() {
 teardown() {
   echo "Cleaning and exit..."
   snap remove --purge "${SNAP}"
+  git restore snap/snapcraft.yaml
 
   rm -rf squashfs-root
 }
@@ -55,7 +56,19 @@ echo "SNAP NAME: ${SNAP}"
 
 pushd "$PROJECT_ROOT" || exit 1
 
-SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS=1 snapcraft -o "${SNAP}".snap
+# 'sudo -u "$RUN_AS"' prevents a permission denied error when using yq as snap.
+RUN_AS="${SUDO_USER:-$LOGNAME}"
+sudo -u "$RUN_AS" yq '.apps.app-rust-2 = {
+  "environment": {
+    "env_alias": "app-rust-2"
+  },
+  "command-chain": [
+    "bin/env-exporter"
+  ],
+  "command": "bin/env.sh"
+}' -i "snap/snapcraft.yaml"
+
+snapcraft -o "${SNAP}".snap
 
 unsquashfs -f "$PROJECT_ROOT/${SNAP}.snap"
 
@@ -73,21 +86,21 @@ echo 'HELLO_WORLD="Hello World"' >>/var/snap/"${SNAP}"/common/global.env
 echo "Load global envfile"
 snap set "${SNAP}" envfile=/var/snap/"${SNAP}"/common/global.env
 
-echo "[TEST] - Check if the global envfile is loaded the app using Rust and bash snappy-env programs"
+echo "[TEST] - Check if the global envfile is loaded the app using Rust snappy-env programs"
 assert_env "${SNAP}.app-rust" "HELLO_WORLD" "Hello World" || fail
-assert_env "${SNAP}.app-bash" "HELLO_WORLD" "Hello World" || fail
+assert_env "${SNAP}.app-rust-2" "HELLO_WORLD" "Hello World" || fail
 
 echo -e "\n[envtester] Creating app-specific envfile"
 echo 'SCOPED=RustVersion' >>/var/snap/"${SNAP}"/common/rust.env
-echo 'SCOPED=BashVersion' >>/var/snap/"${SNAP}"/common/bash.env
+echo 'SCOPED=Rust2Version' >>/var/snap/"${SNAP}"/common/rust-2.env
 
 echo "Load app-specific envfile"
 snap set "${SNAP}" apps.app-rust.envfile=/var/snap/"${SNAP}"/common/rust.env
-snap set "${SNAP}" apps.app-bash.envfile=/var/snap/"${SNAP}"/common/bash.env
+snap set "${SNAP}" apps.app-rust-2.envfile=/var/snap/"${SNAP}"/common/rust-2.env
 
 echo "[TEST] - Check if the app-specific envfile is loaded for the apps"
 assert_env "${SNAP}.app-rust" "SCOPED" "RustVersion" || fail
-assert_env "${SNAP}.app-bash" "SCOPED" "BashVersion" || fail
+assert_env "${SNAP}.app-rust-2" "SCOPED" "Rust2Version" || fail
 
 echo -e "\n[envtester] Setting global env variable"
 
@@ -96,21 +109,21 @@ snap set "${SNAP}" env.global="World"
 
 echo "[TEST] - Check if the global env var is set for all apps"
 assert_env "${SNAP}.app-rust" "GLOBAL" "World" || fail
-assert_env "${SNAP}.app-bash" "GLOBAL" "World" || fail
+assert_env "${SNAP}.app-rust-2" "GLOBAL" "World" || fail
 
 echo -e "\n[envtester] Setting app-specific env variable"
 echo "Set env vars: specific to each app"
 snap set "${SNAP}" apps.app-rust.env.hello="Hello"
-snap set "${SNAP}" apps.app-bash.env.specific="City"
+snap set "${SNAP}" apps.app-rust-2.env.specific="City"
 
 echo "[TEST] - Check if the app-specific env var IS SET for the app 'app-rust'"
 assert_env "${SNAP}.app-rust" "HELLO" "Hello" || fail
 
-echo -e "\n[TEST] [WARN EXPECTED] - Check if the app-specific env var IS NOT SET for the app 'app-bash'"
-! assert_env "${SNAP}.app-bash" "HELLO" "Hello" || fail
+echo -e "\n[TEST] [WARN EXPECTED] - Check if the app-specific env var IS NOT SET for the app 'app-rust-2'"
+! assert_env "${SNAP}.app-rust-2" "HELLO" "Hello" || fail
 
-echo -e "\n[TEST] - Check if the app-specific env var IS SET for the app 'app-bash'"
-assert_env "${SNAP}.app-bash" "SPECIFIC" "City" || fail
+echo -e "\n[TEST] - Check if the app-specific env var IS SET for the app 'app-rust-2'"
+assert_env "${SNAP}.app-rust-2" "SPECIFIC" "City" || fail
 
 echo -e "\n[TEST] [WARN EXPECTED] - Check if the app-specific env var IS NOT SET for the app 'app-rust'"
 ! assert_env "${SNAP}.app-rust" "SPECIFIC" "City" || fail

--- a/tests/test-snappyenv
+++ b/tests/test-snappyenv
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -eux
+set -eu
 
 BASEDIR=$(dirname "$(realpath "$0")")
 
@@ -67,7 +67,7 @@ echo "Check that the exec-env script is present"
 
 snap install "${SNAP}".snap --dangerous
 
-echo "[envtester] Creating global envfile"
+echo -e "\n[envtester] Creating global envfile"
 echo 'HELLO_WORLD="Hello World"' >>/var/snap/"${SNAP}"/common/global.env
 
 echo "Load global envfile"
@@ -77,7 +77,7 @@ echo "[TEST] - Check if the global envfile is loaded the app using Rust and bash
 assert_env "${SNAP}.app-rust" "HELLO_WORLD" "Hello World" || fail
 assert_env "${SNAP}.app-bash" "HELLO_WORLD" "Hello World" || fail
 
-echo "[envtester] Creating app-specific envfile"
+echo -e "\n[envtester] Creating app-specific envfile"
 echo 'SCOPED=RustVersion' >>/var/snap/"${SNAP}"/common/rust.env
 echo 'SCOPED=BashVersion' >>/var/snap/"${SNAP}"/common/bash.env
 
@@ -89,7 +89,7 @@ echo "[TEST] - Check if the app-specific envfile is loaded for the apps"
 assert_env "${SNAP}.app-rust" "SCOPED" "RustVersion" || fail
 assert_env "${SNAP}.app-bash" "SCOPED" "BashVersion" || fail
 
-echo "[envtester] Setting global env variable"
+echo -e "\n[envtester] Setting global env variable"
 
 echo "Set env vars: Global"
 snap set "${SNAP}" env.global="World"
@@ -98,7 +98,7 @@ echo "[TEST] - Check if the global env var is set for all apps"
 assert_env "${SNAP}.app-rust" "GLOBAL" "World" || fail
 assert_env "${SNAP}.app-bash" "GLOBAL" "World" || fail
 
-echo "[envtester] Setting app-specific env variable"
+echo -e "\n[envtester] Setting app-specific env variable"
 echo "Set env vars: specific to each app"
 snap set "${SNAP}" apps.app-rust.env.hello="Hello"
 snap set "${SNAP}" apps.app-bash.env.specific="City"
@@ -106,25 +106,25 @@ snap set "${SNAP}" apps.app-bash.env.specific="City"
 echo "[TEST] - Check if the app-specific env var IS SET for the app 'app-rust'"
 assert_env "${SNAP}.app-rust" "HELLO" "Hello" || fail
 
-echo "[TEST] [WARN EXPECTED] - Check if the app-specific env var IS NOT SET for the app 'app-bash'"
+echo -e "\n[TEST] [WARN EXPECTED] - Check if the app-specific env var IS NOT SET for the app 'app-bash'"
 ! assert_env "${SNAP}.app-bash" "HELLO" "Hello" || fail
 
-echo "[TEST] - Check if the app-specific env var IS SET for the app 'app-bash'"
+echo -e "\n[TEST] - Check if the app-specific env var IS SET for the app 'app-bash'"
 assert_env "${SNAP}.app-bash" "SPECIFIC" "City" || fail
 
-echo "[TEST] [WARN EXPECTED] - Check if the app-specific env var IS NOT SET for the app 'app-rust'"
+echo -e "\n[TEST] [WARN EXPECTED] - Check if the app-specific env var IS NOT SET for the app 'app-rust'"
 ! assert_env "${SNAP}.app-rust" "SPECIFIC" "City" || fail
 
+echo -e "\n[envtester] Testing options syntax"
 snap set "${SNAP}" env.word.dot="wrong"
 echo "[TEST] [WARN EXPECTED] - Check if the key with dot was ignored"
 ! assert_env "${SNAP}.app-rust" "" "wrong" || fail
 
-echo "[envtester] Testing order of env vars"
+echo -e "\n[envtester] Testing order of env vars"
 echo 'ORDER="From envfile"' >>/var/snap/"${SNAP}"/common/local.env
 snap set "${SNAP}" apps.app-rust.env.order="from app-specific"
 snap set "${SNAP}" apps.app-rust.envfile=/var/snap/"${SNAP}"/common/local.env
 echo "[TEST] - Check if local overrites global"
-
 assert_env "${SNAP}.app-rust" "ORDER" "from app-specific" || fail
 
 teardown

--- a/tests/test-snappyenv
+++ b/tests/test-snappyenv
@@ -2,85 +2,14 @@
 
 set -eu
 
-check_syntax() {
-  local snap_app="$1"
-  local env_value="$2"
-  if eval "$snap_app" | grep -q "^${env_value}="; then
-    echo -e "\n[ERROR] Value '$env_name' SHOULD NOT BE set.\n"
-    return 1
-  fi
-  return 0
-}
-
-check_env_exist() {
-  local snap_app="$1"
-  local env_name="$2"
-
-  if ! eval "$snap_app" | grep -q "^${env_name}="; then
-    echo -e "\n[ERROR] Environment variable '$env_name' is not set, for the app: $snap_app.\n"
-    return 1
-  fi
-}
-
-check_env_not_exist() {
-
-  local snap_app="$1"
-  local env_name="$2"
-
-  if eval "$snap_app" | grep -q "^${env_name}="; then
-    echo -e "\n[ERROR] Environment variable '$env_name' SHOULD NOT be set, for the app: $snap_app.\n"
-    return 1
-  fi
-}
-
-check_env_value() {
-  local snap_app="$1"
-  local env_name="$2"
-  local exp_value="$3"
-  local actual_value
-
-  if [ -z "$env_name" ]; then
-    echo -e "\n\nHERE HERE\n\n "
-    empty=$("$snap_app" | grep "=${exp_value}")
-    [ -z "$empty" ] || return 1
-  fi
-  actual_value=$("$snap_app" | grep "^${env_name}=" | cut -d'=' -f2-)
-  if [ "$actual_value" != "$exp_value" ]; then
-    echo -e "\n[ERROR] Environment variable '$env_name' does not match the expected value, for the app: $snap_app"
-    echo -e "[ERROR] Expected: '$env_name=$exp_value', but got: '$env_name=$actual_value'\n"
-    return 1
-  fi
-}
-
-check_root() {
-  if [ "$USER" != "root" ]; then
-    echo -e "Please run as root.\n"
-    exit 1
-  fi
-}
-
-clean() {
-  echo "Cleaning..."
-  snap remove --purge "${SNAP}"
-  git restore snap/snapcraft.yaml
-  sudo chown $SUDO_USER:$SUDO_USER snap/snapcraft.yaml
-
-  rm -rf squashfs-root
-}
-
-fail() {
-  clean
-  exit 1
-}
-
 BASEDIR=$(dirname "$(realpath "$0")")
 PROJECT_ROOT="$BASEDIR/.."
 
-SNAP=envtester
-SNAP_COMMON=/var/snap/"${SNAP}"/common/
+. $PROJECT_ROOT/tests/initialize
 
 check_root
 clean
+init_tests
 
 echo "SNAP NAME: ${SNAP}"
 
@@ -97,8 +26,6 @@ sudo -u "$SUDO_USER" yq '.apps.app-rust-2 = {
   "command": "bin/env.sh"
 }' -i "snap/snapcraft.yaml"
 
-snapcraft -o "${SNAP}".snap
-
 unsquashfs "${PROJECT_ROOT}/${SNAP}.snap"
 
 echo "Check that the env-exporter program is present"
@@ -106,8 +33,6 @@ echo "Check that the env-exporter program is present"
 
 echo "Check that the exec-env script is present"
 [ -f squashfs-root/bin/env.sh ] || fail
-
-snap install "${SNAP}".snap --dangerous
 
 echo -e "\n[envtester] Creating global envfile"
 echo 'HELLO_WORLD="Hello World"' >>"$SNAP_COMMON"/global.env

--- a/tests/test-snappyenv
+++ b/tests/test-snappyenv
@@ -106,6 +106,7 @@ echo -e "\n[envtester] Testing options syntax"
 snap set "${SNAP}" env.word.dot="wrong"
 echo "[TEST] - Check if the key with dot was ignored"
 check_syntax "${SNAP}.app-rust" "wrong" || fail
+snap unset "${SNAP}" env.word.dot
 
 clean
 popd || exit 1

--- a/tests/test-snappyenv
+++ b/tests/test-snappyenv
@@ -57,7 +57,7 @@ pushd "$PROJECT_ROOT" || exit 1
 
 SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS=1 snapcraft -o "${SNAP}".snap
 
-unsquashfs "$PROJECT_ROOT/${SNAP}.snap"
+unsquashfs -f "$PROJECT_ROOT/${SNAP}.snap"
 
 echo "Check that the env-exporter program is present"
 [ -f squashfs-root/bin/env-exporter ] || fail

--- a/tests/test-snappyenv
+++ b/tests/test-snappyenv
@@ -2,30 +2,54 @@
 
 set -eu
 
-BASEDIR=$(dirname "$(realpath "$0")")
+check_syntax() {
+  local snap_app="$1"
+  local env_value="$2"
+  if eval "$snap_app" | grep -q "^${env_value}="; then
+    echo -e "\n[ERROR] Value '$env_name' SHOULD NOT BE set.\n"
+    return 1
+  fi
+  return 0
+}
 
-PROJECT_ROOT="$BASEDIR/.."
+check_env_exist() {
+  local snap_app="$1"
+  local env_name="$2"
 
-assert_env() {
+  if ! eval "$snap_app" | grep -q "^${env_name}="; then
+    echo -e "\n[ERROR] Environment variable '$env_name' is not set, for the app: $snap_app.\n"
+    return 1
+  fi
+}
+
+check_env_not_exist() {
+
+  local snap_app="$1"
+  local env_name="$2"
+
+  if eval "$snap_app" | grep -q "^${env_name}="; then
+    echo -e "\n[ERROR] Environment variable '$env_name' SHOULD NOT be set, for the app: $snap_app.\n"
+    return 1
+  fi
+}
+
+check_env_value() {
   local snap_app="$1"
   local env_name="$2"
   local exp_value="$3"
   local actual_value
-  if ! eval "$snap_app" | grep -q "^${env_name}="; then
-    echo -e "\n[WARN] Environment variable '$env_name' is not set.\n"
-    return 1
-  fi
+
   if [ -z "$env_name" ]; then
+    echo -e "\n\nHERE HERE\n\n "
     empty=$("$snap_app" | grep "=${exp_value}")
     [ -z "$empty" ] || return 1
   fi
   actual_value=$("$snap_app" | grep "^${env_name}=" | cut -d'=' -f2-)
   if [ "$actual_value" != "$exp_value" ]; then
-    echo -e "\n[ERROR] Environment variable '$env_name' does not match the expected value."
+    echo -e "\n[ERROR] Environment variable '$env_name' does not match the expected value, for the app: $snap_app"
     echo -e "[ERROR] Expected: '$env_name=$exp_value', but got: '$env_name=$actual_value'\n"
     return 1
   fi
-  return 0
 }
 
 check_root() {
@@ -35,30 +59,35 @@ check_root() {
   fi
 }
 
-teardown() {
-  echo "Cleaning and exit..."
+clean() {
+  echo "Cleaning..."
   snap remove --purge "${SNAP}"
   git restore snap/snapcraft.yaml
+  sudo chown $SUDO_USER:$SUDO_USER snap/snapcraft.yaml
 
   rm -rf squashfs-root
 }
 
 fail() {
-  teardown
+  clean
   exit 1
 }
 
-check_root
+BASEDIR=$(dirname "$(realpath "$0")")
+PROJECT_ROOT="$BASEDIR/.."
 
 SNAP=envtester
+SNAP_COMMON=/var/snap/"${SNAP}"/common/
+
+check_root
+clean
 
 echo "SNAP NAME: ${SNAP}"
 
 pushd "$PROJECT_ROOT" || exit 1
 
 # 'sudo -u "$RUN_AS"' prevents a permission denied error when using yq as snap.
-RUN_AS="${SUDO_USER:-$LOGNAME}"
-sudo -u "$RUN_AS" yq '.apps.app-rust-2 = {
+sudo -u "$SUDO_USER" yq '.apps.app-rust-2 = {
   "environment": {
     "env_alias": "app-rust-2"
   },
@@ -70,7 +99,7 @@ sudo -u "$RUN_AS" yq '.apps.app-rust-2 = {
 
 snapcraft -o "${SNAP}".snap
 
-unsquashfs -f "$PROJECT_ROOT/${SNAP}.snap"
+unsquashfs "${PROJECT_ROOT}/${SNAP}.snap"
 
 echo "Check that the env-exporter program is present"
 [ -f squashfs-root/bin/env-exporter ] || fail
@@ -81,26 +110,32 @@ echo "Check that the exec-env script is present"
 snap install "${SNAP}".snap --dangerous
 
 echo -e "\n[envtester] Creating global envfile"
-echo 'HELLO_WORLD="Hello World"' >>/var/snap/"${SNAP}"/common/global.env
+echo 'HELLO_WORLD="Hello World"' >>"$SNAP_COMMON"/global.env
 
 echo "Load global envfile"
-snap set "${SNAP}" envfile=/var/snap/"${SNAP}"/common/global.env
+snap set "${SNAP}" envfile="$SNAP_COMMON"/global.env
 
 echo "[TEST] - Check if the global envfile is loaded the app using Rust snappy-env programs"
-assert_env "${SNAP}.app-rust" "HELLO_WORLD" "Hello World" || fail
-assert_env "${SNAP}.app-rust-2" "HELLO_WORLD" "Hello World" || fail
+check_env_exist "${SNAP}.app-rust" "HELLO_WORLD" || fail
+check_env_value "${SNAP}.app-rust" "HELLO_WORLD" "Hello World" || fail
+
+check_env_exist "${SNAP}.app-rust-2" "HELLO_WORLD" || fail
+check_env_value "${SNAP}.app-rust-2" "HELLO_WORLD" "Hello World" || fail
 
 echo -e "\n[envtester] Creating app-specific envfile"
-echo 'SCOPED=RustVersion' >>/var/snap/"${SNAP}"/common/rust.env
-echo 'SCOPED=Rust2Version' >>/var/snap/"${SNAP}"/common/rust-2.env
+echo 'SCOPED=RustVersion' >>"$SNAP_COMMON"/rust.env
+echo 'SCOPED=Rust2Version' >>"$SNAP_COMMON"/rust-2.env
 
 echo "Load app-specific envfile"
-snap set "${SNAP}" apps.app-rust.envfile=/var/snap/"${SNAP}"/common/rust.env
-snap set "${SNAP}" apps.app-rust-2.envfile=/var/snap/"${SNAP}"/common/rust-2.env
+snap set "${SNAP}" apps.app-rust.envfile="$SNAP_COMMON"/rust.env
+snap set "${SNAP}" apps.app-rust-2.envfile="$SNAP_COMMON"/rust-2.env
 
 echo "[TEST] - Check if the app-specific envfile is loaded for the apps"
-assert_env "${SNAP}.app-rust" "SCOPED" "RustVersion" || fail
-assert_env "${SNAP}.app-rust-2" "SCOPED" "Rust2Version" || fail
+check_env_exist "${SNAP}.app-rust" "SCOPED" || fail
+check_env_value "${SNAP}.app-rust" "SCOPED" "RustVersion" || fail
+
+check_env_exist "${SNAP}.app-rust-2" "SCOPED" || fail
+check_env_value "${SNAP}.app-rust-2" "SCOPED" "Rust2Version" || fail
 
 echo -e "\n[envtester] Setting global env variable"
 
@@ -108,8 +143,11 @@ echo "Set env vars: Global"
 snap set "${SNAP}" env.global="World"
 
 echo "[TEST] - Check if the global env var is set for all apps"
-assert_env "${SNAP}.app-rust" "GLOBAL" "World" || fail
-assert_env "${SNAP}.app-rust-2" "GLOBAL" "World" || fail
+check_env_exist "${SNAP}.app-rust" "GLOBAL" || fail
+check_env_value "${SNAP}.app-rust" "GLOBAL" "World" || fail
+
+check_env_exist "${SNAP}.app-rust-2" "GLOBAL" || fail
+check_env_value "${SNAP}.app-rust-2" "GLOBAL" "World" || fail
 
 echo -e "\n[envtester] Setting app-specific env variable"
 echo "Set env vars: specific to each app"
@@ -117,29 +155,33 @@ snap set "${SNAP}" apps.app-rust.env.hello="Hello"
 snap set "${SNAP}" apps.app-rust-2.env.specific="City"
 
 echo "[TEST] - Check if the app-specific env var IS SET for the app 'app-rust'"
-assert_env "${SNAP}.app-rust" "HELLO" "Hello" || fail
+check_env_exist "${SNAP}.app-rust" "HELLO" || fail
+check_env_value "${SNAP}.app-rust" "HELLO" "Hello" || fail
 
-echo -e "\n[TEST] [WARN EXPECTED] - Check if the app-specific env var IS NOT SET for the app 'app-rust-2'"
-! assert_env "${SNAP}.app-rust-2" "HELLO" "Hello" || fail
+echo -e "\n[TEST] - Check if the app-specific env var IS NOT SET for the app 'app-rust-2'"
+check_env_not_exist "${SNAP}.app-rust-2" "HELLO" || fail
 
 echo -e "\n[TEST] - Check if the app-specific env var IS SET for the app 'app-rust-2'"
-assert_env "${SNAP}.app-rust-2" "SPECIFIC" "City" || fail
+check_env_exist "${SNAP}.app-rust-2" "SPECIFIC" || fail
+check_env_value "${SNAP}.app-rust-2" "SPECIFIC" "City" || fail
 
-echo -e "\n[TEST] [WARN EXPECTED] - Check if the app-specific env var IS NOT SET for the app 'app-rust'"
-! assert_env "${SNAP}.app-rust" "SPECIFIC" "City" || fail
+echo -e "\n[TEST] - Check if the app-specific env var IS NOT SET for the app 'app-rust'"
+check_env_not_exist "${SNAP}.app-rust" "SPECIFIC" || fail
 
 echo -e "\n[envtester] Testing options syntax"
 snap set "${SNAP}" env.word.dot="wrong"
-echo "[TEST] [WARN EXPECTED] - Check if the key with dot was ignored"
-! assert_env "${SNAP}.app-rust" "" "wrong" || fail
+echo "[TEST] - Check if the key with dot was ignored"
+check_syntax "${SNAP}.app-rust" "wrong" || fail
 
 echo -e "\n[envtester] Testing order of env vars"
-echo 'ORDER="From envfile"' >>/var/snap/"${SNAP}"/common/local.env
+echo 'ORDER="From envfile"' >>"$SNAP_COMMON"/local.env
 snap set "${SNAP}" apps.app-rust.env.order="from app-specific"
-snap set "${SNAP}" apps.app-rust.envfile=/var/snap/"${SNAP}"/common/local.env
-echo "[TEST] - Check if local overrites global"
-assert_env "${SNAP}.app-rust" "ORDER" "from app-specific" || fail
+snap set "${SNAP}" apps.app-rust.envfile="$SNAP_COMMON"/local.env
+echo "[TEST] - Check if local overrides global"
 
-teardown
+check_env_exist "${SNAP}.app-rust" "ORDER" || fail
+check_env_value "${SNAP}.app-rust" "ORDER" "from app-specific" || fail
+
+clean
 popd || exit 1
 exit 0

--- a/tests/test-snappyenv
+++ b/tests/test-snappyenv
@@ -93,19 +93,19 @@ check_env_value "${SNAP}.app-rust-2" "SPECIFIC" "City" || fail
 echo -e "\n[TEST] - Check if the app-specific env var IS NOT SET for the app 'app-rust'"
 check_env_not_exist "${SNAP}.app-rust" "SPECIFIC" || fail
 
-echo -e "\n[envtester] Testing options syntax"
-snap set "${SNAP}" env.word.dot="wrong"
-echo "[TEST] - Check if the key with dot was ignored"
-check_syntax "${SNAP}.app-rust" "wrong" || fail
-
 echo -e "\n[envtester] Testing order of env vars"
 echo 'ORDER="From envfile"' >>"$SNAP_COMMON"/local.env
-snap set "${SNAP}" apps.app-rust.env.order="from app-specific"
+snap set "${SNAP}" apps.app-rust.env.order="from snap option"
 snap set "${SNAP}" apps.app-rust.envfile="$SNAP_COMMON"/local.env
 echo "[TEST] - Check if local overrides global"
 
 check_env_exist "${SNAP}.app-rust" "ORDER" || fail
-check_env_value "${SNAP}.app-rust" "ORDER" "from app-specific" || fail
+check_env_value "${SNAP}.app-rust" "ORDER" "from snap option" || fail
+
+echo -e "\n[envtester] Testing options syntax"
+snap set "${SNAP}" env.word.dot="wrong"
+echo "[TEST] - Check if the key with dot was ignored"
+check_syntax "${SNAP}.app-rust" "wrong" || fail
 
 clean
 popd || exit 1

--- a/tests/test-snappyenv
+++ b/tests/test-snappyenv
@@ -1,0 +1,132 @@
+#!/bin/bash
+
+set -eux
+
+BASEDIR=$(dirname "$(realpath "$0")")
+
+PROJECT_ROOT="$BASEDIR/.."
+
+assert_env() {
+  local snap_app="$1"
+  local env_name="$2"
+  local exp_value="$3"
+  local actual_value
+  if ! eval "$snap_app" | grep -q "^${env_name}="; then
+    echo -e "\n[WARN] Environment variable '$env_name' is not set.\n"
+    return 1
+  fi
+  if [ -z "$env_name" ]; then
+    empty=$("$snap_app" | grep "=${exp_value}")
+    [ -z "$empty" ] || return 1
+  fi
+  actual_value=$("$snap_app" | grep "^${env_name}=" | cut -d'=' -f2-)
+  if [ "$actual_value" != "$exp_value" ]; then
+    echo -e "\n[ERROR] Environment variable '$env_name' does not match the expected value."
+    echo -e "[ERROR] Expected: '$env_name=$exp_value', but got: '$env_name=$actual_value'\n"
+    return 1
+  fi
+  return 0
+}
+
+check_root() {
+  if [ "$USER" != "root" ]; then
+    echo -e "Please run as root.\n"
+    exit 1
+  fi
+}
+
+teardown() {
+  echo "Cleaning and exit..."
+  snap remove --purge "${SNAP}"
+
+  rm -rf squashfs-root
+}
+
+fail() {
+  teardown
+  exit 1
+}
+
+check_root
+
+SNAP=envtester
+
+echo "SNAP NAME: ${SNAP}"
+
+pushd "$PROJECT_ROOT" || exit 1
+
+SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS=1 snapcraft -o "${SNAP}".snap
+
+unsquashfs "$PROJECT_ROOT/${SNAP}.snap"
+
+echo "Check that the env-exporter program is present"
+[ -f squashfs-root/bin/env-exporter ] || fail
+
+echo "Check that the exec-env script is present"
+[ -f squashfs-root/bin/env.sh ] || fail
+
+snap install "${SNAP}".snap --dangerous
+
+echo "[envtester] Creating global envfile"
+echo 'HELLO_WORLD="Hello World"' >>/var/snap/"${SNAP}"/common/global.env
+
+echo "Load global envfile"
+snap set "${SNAP}" envfile=/var/snap/"${SNAP}"/common/global.env
+
+echo "[TEST] - Check if the global envfile is loaded the app using Rust and bash snappy-env programs"
+assert_env "${SNAP}.app-rust" "HELLO_WORLD" "Hello World" || fail
+assert_env "${SNAP}.app-bash" "HELLO_WORLD" "Hello World" || fail
+
+echo "[envtester] Creating app-specific envfile"
+echo 'SCOPED=RustVersion' >>/var/snap/"${SNAP}"/common/rust.env
+echo 'SCOPED=BashVersion' >>/var/snap/"${SNAP}"/common/bash.env
+
+echo "Load app-specific envfile"
+snap set "${SNAP}" apps.app-rust.envfile=/var/snap/"${SNAP}"/common/rust.env
+snap set "${SNAP}" apps.app-bash.envfile=/var/snap/"${SNAP}"/common/bash.env
+
+echo "[TEST] - Check if the app-specific envfile is loaded for the apps"
+assert_env "${SNAP}.app-rust" "SCOPED" "RustVersion" || fail
+assert_env "${SNAP}.app-bash" "SCOPED" "BashVersion" || fail
+
+echo "[envtester] Setting global env variable"
+
+echo "Set env vars: Global"
+snap set "${SNAP}" env.global="World"
+
+echo "[TEST] - Check if the global env var is set for all apps"
+assert_env "${SNAP}.app-rust" "GLOBAL" "World" || fail
+assert_env "${SNAP}.app-bash" "GLOBAL" "World" || fail
+
+echo "[envtester] Setting app-specific env variable"
+echo "Set env vars: specific to each app"
+snap set "${SNAP}" apps.app-rust.env.hello="Hello"
+snap set "${SNAP}" apps.app-bash.env.specific="City"
+
+echo "[TEST] - Check if the app-specific env var IS SET for the app 'app-rust'"
+assert_env "${SNAP}.app-rust" "HELLO" "Hello" || fail
+
+echo "[TEST] [WARN EXPECTED] - Check if the app-specific env var IS NOT SET for the app 'app-bash'"
+! assert_env "${SNAP}.app-bash" "HELLO" "Hello" || fail
+
+echo "[TEST] - Check if the app-specific env var IS SET for the app 'app-bash'"
+assert_env "${SNAP}.app-bash" "SPECIFIC" "City" || fail
+
+echo "[TEST] [WARN EXPECTED] - Check if the app-specific env var IS NOT SET for the app 'app-rust'"
+! assert_env "${SNAP}.app-rust" "SPECIFIC" "City" || fail
+
+snap set "${SNAP}" env.word.dot="wrong"
+echo "[TEST] [WARN EXPECTED] - Check if the key with dot was ignored"
+! assert_env "${SNAP}.app-rust" "" "wrong" || fail
+
+echo "[envtester] Testing order of env vars"
+echo 'ORDER="From envfile"' >>/var/snap/"${SNAP}"/common/local.env
+snap set "${SNAP}" apps.app-rust.env.order="from app-specific"
+snap set "${SNAP}" apps.app-rust.envfile=/var/snap/"${SNAP}"/common/local.env
+echo "[TEST] - Check if local overrites global"
+
+assert_env "${SNAP}.app-rust" "ORDER" "from app-specific" || fail
+
+teardown
+popd || exit 1
+exit 0


### PR DESCRIPTION
The tests' coverage isn't perfect, for sure, but covers the basic functionality for the snappy-env program. The focus has given on the **Rust** version rather than the **Bash** one.